### PR TITLE
Improve student activity registration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/MattiasAndersen/skills-getting-started-with-github-copilot/issues/1)
 
+## Running Backend Tests
+
+From the repository root:
+
+```bash
+/usr/local/bin/python -m pip install -r requirements.txt
+/usr/local/bin/python -m pytest
+```
+
+The backend tests are located in the `tests/` directory and follow the Arrange-Act-Assert (AAA) pattern.
+
 ---
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Team practices, drills, and inter-school basketball matches",
+        "schedule": "Mondays and Wednesdays, 3:45 PM - 5:15 PM",
+        "max_participants": 15,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Soccer Club": {
+        "description": "Skill development, scrimmages, and friendly soccer competitions",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting workshops and stage performances throughout the semester",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["isabella@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Painting Workshop": {
+        "description": "Explore drawing and painting techniques with creative projects",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["amelia@mergington.edu", "henry@mergington.edu"]
+    },
+    "Debate Society": {
+        "description": "Practice public speaking, argumentation, and competitive debates",
+        "schedule": "Mondays, 3:30 PM - 4:45 PM",
+        "max_participants": 14,
+        "participants": ["charlotte@mergington.edu", "james@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Hands-on experiments and collaborative science investigation projects",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 22,
+        "participants": ["benjamin@mergington.edu", "harper@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsMarkup = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${participant}</span>
+                    <button
+                      type="button"
+                      class="participant-remove"
+                      data-activity="${encodeURIComponent(name)}"
+                      data-email="${encodeURIComponent(participant)}"
+                      aria-label="Unregister ${participant} from ${name}"
+                      title="Unregister participant"
+                    >
+                      🗑
+                    </button>
+                  </li>
+                `
+              )
+              .join("")
+          : '<li class="participants-empty">No participants yet</li>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants:</strong></p>
+            <ul class="participants-list">
+              ${participantsMarkup}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -40,6 +68,46 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error fetching activities:", error);
     }
   }
+
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".participant-remove");
+    if (!removeButton) {
+      return;
+    }
+
+    const activity = decodeURIComponent(removeButton.dataset.activity || "");
+    const email = decodeURIComponent(removeButton.dataset.email || "");
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Unable to unregister participant";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
+    }
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
@@ -62,6 +130,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,66 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e4e4e4;
+}
+
+.participants-title {
+  margin-bottom: 6px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  color: #444;
+  word-break: break-word;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  background-color: #ffffff;
+  border: 1px solid #e9e9e9;
+  border-radius: 4px;
+}
+
+.participant-email {
+  flex: 1;
+}
+
+.participant-remove {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px;
+}
+
+.participant-remove:hover {
+  transform: scale(1.08);
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.participants-empty {
+  color: #777;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_activities = copy.deepcopy(activities)
+
+    yield
+
+    activities.clear()
+    activities.update(copy.deepcopy(original_activities))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,122 @@
+from src.app import activities
+
+
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    endpoint = "/"
+
+    # Act
+    response = client.get(endpoint, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_all_activity_data(client):
+    # Arrange
+    endpoint = "/activities"
+
+    # Act
+    response = client.get(endpoint)
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(payload, dict)
+    assert "Chess Club" in payload
+    assert {"description", "schedule", "max_participants", "participants"}.issubset(
+        payload["Chess Club"].keys()
+    )
+
+
+def test_signup_adds_participant_successfully(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+    endpoint = f"/activities/{activity_name}/signup"
+
+    # Act
+    response = client.post(endpoint, params={"email": email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert payload == {"message": f"Signed up {email} for {activity_name}"}
+    assert email in activities[activity_name]["participants"]
+
+
+def test_signup_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "student@mergington.edu"
+    endpoint = f"/activities/{activity_name}/signup"
+
+    # Act
+    response = client.post(endpoint, params={"email": email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload == {"detail": "Activity not found"}
+
+
+def test_signup_returns_bad_request_for_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = activities[activity_name]["participants"][0]
+    endpoint = f"/activities/{activity_name}/signup"
+
+    # Act
+    response = client.post(endpoint, params={"email": existing_email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 400
+    assert payload == {"detail": "Student already signed up for this activity"}
+
+
+def test_unregister_removes_participant_successfully(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = activities[activity_name]["participants"][0]
+    endpoint = f"/activities/{activity_name}/signup"
+
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert payload == {"message": f"Unregistered {email} from {activity_name}"}
+    assert email not in activities[activity_name]["participants"]
+
+
+def test_unregister_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "student@mergington.edu"
+    endpoint = f"/activities/{activity_name}/signup"
+
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload == {"detail": "Activity not found"}
+
+
+def test_unregister_returns_not_found_for_non_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "not.registered@mergington.edu"
+    endpoint = f"/activities/{activity_name}/signup"
+
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 404
+    assert payload == {"detail": "Student is not signed up for this activity"}


### PR DESCRIPTION
This pull request introduces several enhancements to the student activity sign-up application, including new backend endpoints, improved frontend participant management, expanded activity data, and comprehensive test coverage. The changes make it possible to unregister students from activities, display participants in the UI, and ensure robust backend functionality through testing.

Backend enhancements:

* Added a new DELETE endpoint (`/activities/{activity_name}/signup`) to allow unregistering a student from an activity, including validation for unknown activities and non-participants.
* Expanded the `activities` data structure in `src/app.py` with additional clubs and teams, each with descriptions, schedules, and participant lists.

Frontend improvements:

* Updated `src/static/app.js` to display participants for each activity, including "remove" buttons for unregistering, and wired up the UI to call the new backend endpoint for participant removal. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R15-R55) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R72-R111)
* Improved participant section styling in `src/static/styles.css` for better visibility and usability.

Testing and documentation:

* Added backend tests in `tests/test_app.py` covering activity listing, sign-up, duplicate sign-up handling, unregistering, and error cases.
* Introduced test fixtures in `tests/conftest.py` to reset activity state between tests, ensuring test isolation.
* Updated `README.md` with instructions for running backend tests.